### PR TITLE
Update old swagger link to graphql playground

### DIFF
--- a/templates/server/src/index.ts
+++ b/templates/server/src/index.ts
@@ -33,7 +33,7 @@ try {
       console.log(`GraphQL Server is now running on http://localhost:${PORT}`);
       //{^isWorkspace//}
       if (firstStartInDevMode) {
-        opn(`http://localhost:${PORT}/graphql`);
+        opn(`http://localhost:${PORT}/graphiql`);
       }
       //{/isWorkspace//}
     }

--- a/templates/server/src/index.ts
+++ b/templates/server/src/index.ts
@@ -33,7 +33,7 @@ try {
       console.log(`GraphQL Server is now running on http://localhost:${PORT}`);
       //{^isWorkspace//}
       if (firstStartInDevMode) {
-        opn(`http://localhost:${PORT}/api/swagger`);
+        opn(`http://localhost:${PORT}/graphql`);
       }
       //{/isWorkspace//}
     }


### PR DESCRIPTION
When I started it, it opened `/api/swagger` - which confused me.

This project doesn't seem to use swagger anywhere, so I would just update it to open the graphql playground